### PR TITLE
ElmoClient constructor has now defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ $ pip install econnect-python
 from elmo import query
 from elmo.api.client import ElmoClient
 
-# Initialize the client with an API endpoint and a vendor and
-# authenticate your connection to retrieve the access token
-client = ElmoClient("https://example.com", "vendor")
+# Initialize a new client to authenticate your connection
+# and retrieve an access token used for the entire session.
+client = ElmoClient()
 client.auth("username", "password")
 
 # To arm/disarm the system you must gain the exclusive Lock()
@@ -66,6 +66,23 @@ disarm the alert, otherwise the API returns `403`.
 Once the lock is obtained, other clients cannot connect to the alarm system and only a
 manual override on the terminal is allowed. Outside the context manager, the lock is
 automatically released.
+
+### Client Configuration
+
+If `https://connect.elmospa.com` is your authentication page, no configuration is needed
+and you can skip this section.
+
+On the other hand, if your authentication page is something similar to
+`https://connect3.elmospa.com/nwd`, you must configure your client as follows:
+
+```python
+# Override the default URL and domain
+client = ElmoClient(base_url="https://connect3.elmospa.com", domain="nwd")
+client.auth("username", "password")
+```
+
+If your `base_url` or `domain` are not properly set, your credentials will not work
+and you will get a `403 Client Error` as your username and password are wrong.
 
 ## Development
 

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -18,7 +18,7 @@ class ElmoClient(object):
 
     Usage:
         # Authenticate to the system (read-only mode)
-        c = ElmoClient("https://example.com", "vendor")
+        c = ElmoClient()
         c.auth("username", "password")
 
         # Obtain a lock to do actions on the system (write mode)
@@ -27,9 +27,9 @@ class ElmoClient(object):
             c.disarm()  # Disarm all alarms
     """
 
-    def __init__(self, base_url, vendor, session_id=None):
+    def __init__(self, base_url=None, domain=None, session_id=None):
         self._router = Router(base_url)
-        self._vendor = vendor
+        self._domain = domain
         self._session = Session()
         self._session_id = session_id
         self._lock = Lock()
@@ -48,7 +48,10 @@ class ElmoClient(object):
             The access token retrieved from the API. The token is also cached in
             the `ElmoClient` instance.
         """
-        payload = {"username": username, "password": password, "domain": self._vendor}
+        payload = {"username": username, "password": password}
+        if self._domain is not None:
+            payload["domain"] = self._domain
+
         response = self._session.get(self._router.auth, params=payload)
         response.raise_for_status()
 

--- a/elmo/api/router.py
+++ b/elmo/api/router.py
@@ -4,7 +4,7 @@ class Router(object):
     """
 
     def __init__(self, base_url):
-        self._base_url = base_url
+        self._base_url = base_url or "https://connect.elmospa.com"
 
     @property
     def auth(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ from elmo.api.client import ElmoClient
 
 @pytest.fixture
 def client():
-    """Create an ElmoClient with a default base URL."""
-    client = ElmoClient("https://example.com", "vendor")
+    """Create an ElmoClient with defaults."""
+    client = ElmoClient("https://example.com", "domain")
     yield client
 
 


### PR DESCRIPTION
### Overview

This change introduces a simpler constructor that has already the following defaults:
* base_url: `https://connect.elmospa.com`
* domain: `None`

To create a client it's enough to:
```python
# Authenticate to the system (read-only mode)
c = ElmoClient()
c.auth("username", "password")
```
or:
```python
# Authenticate to the system with configuration (read-only mode)
c = ElmoClient(base_url="https://connect3.elmospa.com, domain="nwd")
c.auth("username", "password")
```

This is not a breaking change and a regression test has been added.
In this change we also removed `vendor` as part of the API because it was meaningless. Now it has been renamed to `domain`.