### PR TITLE
Introduce a safer API so that only HTTPS urls can be used

### DIFF
--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -10,6 +10,12 @@ class BaseException(Exception):
         return str(self.message)
 
 
+class ValidationError(BaseException):
+    """Exception raised when a Validator fails."""
+
+    pass
+
+
 class QueryNotValid(BaseException):
     """Exception raised when a Query is not valid."""
 

--- a/elmo/api/router.py
+++ b/elmo/api/router.py
@@ -1,10 +1,21 @@
+from urllib.parse import urlparse
+
+from .exceptions import ValidationError
+
+
 class Router(object):
     """API router class that holds a list of endpoints
     grouped by action type.
     """
 
     def __init__(self, base_url):
-        self._base_url = base_url or "https://connect.elmospa.com"
+        # Enforce the value is a valid URL behind HTTPS
+        base_url = base_url or "https://connect.elmospa.com"
+        url = urlparse(base_url)
+        if url.scheme != "https":
+            raise ValidationError("The schema must be HTTPS")
+
+        self._base_url = base_url
 
     @property
     def auth(self):

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,10 @@
+import pytest
+
+from elmo.api.router import Router
+from elmo.api.exceptions import ValidationError
+
+
+def test_https_is_required():
+    """Should accept only HTTPS URLs."""
+    with pytest.raises(ValidationError):
+        Router("http://connect.elmospa.com")


### PR DESCRIPTION
### Overview

Closes #58 

By design, the client must not accept any URL that is not encrypted (HTTPS). If a non-HTTPS url is used, a `ValidationError` is raised to the main application.

There is no way to bypass this, so in case you _really_ need an `http` endpoint, feel free to [open a new issue](https://github.com/palazzem/econnect-python/issues) so we can discuss the requirement there. The main reason why I prefer this approach, is because such credentials are _really_ sensitive (they control your home alarm system) and so I'd prefer to prevent any possible typo/unwanted mistake.

### Usage

```python
ElmoClient(base_url="http://example.com")     # Raises ValidationError exception
ElmoClient(base_url="https://example.com")    # Is accepted
```