### PR TITLE
Handle token expiration

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -1,5 +1,3 @@
-import time
-
 from threading import Lock
 from contextlib import contextmanager
 from functools import lru_cache
@@ -58,10 +56,9 @@ class ElmoClient(object):
         response = self._session.get(self._router.auth, params=payload)
         response.raise_for_status()
 
-        # Store the session_id and the token expiration (10 minutes)
+        # Store the session_id
         data = response.json()
         self._session_id = data["SessionId"]
-        self._session_expire = time.time() + 60 * 10
 
         # Register the redirect URL and try the authentication again
         if data["Redirect"]:

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -1,3 +1,5 @@
+import time
+
 from threading import Lock
 from contextlib import contextmanager
 from functools import lru_cache
@@ -32,6 +34,7 @@ class ElmoClient(object):
         self._domain = domain
         self._session = Session()
         self._session_id = session_id
+        self._session_expire = 0
         self._lock = Lock()
         self._strings = None
 
@@ -55,9 +58,10 @@ class ElmoClient(object):
         response = self._session.get(self._router.auth, params=payload)
         response.raise_for_status()
 
-        # Store the session_id
+        # Store the session_id and the token expiration (10 minutes)
         data = response.json()
         self._session_id = data["SessionId"]
+        self._session_expire = time.time() + 60 * 10
 
         # Register the redirect URL and try the authentication again
         if data["Redirect"]:

--- a/elmo/api/decorators.py
+++ b/elmo/api/decorators.py
@@ -1,4 +1,4 @@
-from .exceptions import PermissionDenied, LockNotAcquired
+from .exceptions import MissingToken, LockNotAcquired
 
 
 def require_session(func):
@@ -7,13 +7,13 @@ def require_session(func):
     `_session_id`.
 
     Raises:
-        InvalidSession: if a `session_id` is not available or expired.
+        MissingToken: if a `session_id` is not available.
     """
 
     def func_wrapper(*args, **kwargs):
         self = args[0]
         if self._session_id is None:
-            raise PermissionDenied("You do not have permission to perform this action.")
+            raise MissingToken
         else:
             return func(*args, **kwargs)
 

--- a/elmo/api/decorators.py
+++ b/elmo/api/decorators.py
@@ -1,5 +1,3 @@
-import time
-
 from .exceptions import MissingToken, ExpiredToken, LockNotAcquired
 
 
@@ -17,9 +15,8 @@ def require_session(func):
         self = args[0]
         if self._session_id is None:
             raise MissingToken
-        elif self._session_expire < time.time():
-            raise ExpiredToken
         else:
+            # TODO: catch exceptions to detect ExpiredToken
             return func(*args, **kwargs)
 
     return func_wrapper

--- a/elmo/api/decorators.py
+++ b/elmo/api/decorators.py
@@ -1,4 +1,6 @@
-from .exceptions import MissingToken, LockNotAcquired
+import time
+
+from .exceptions import MissingToken, ExpiredToken, LockNotAcquired
 
 
 def require_session(func):
@@ -8,12 +10,15 @@ def require_session(func):
 
     Raises:
         MissingToken: if a `session_id` is not available.
+        ExpiredToken: if stored `session_id` is expired.
     """
 
     def func_wrapper(*args, **kwargs):
         self = args[0]
         if self._session_id is None:
             raise MissingToken
+        elif self._session_expire < time.time():
+            raise ExpiredToken
         else:
             return func(*args, **kwargs)
 

--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -13,7 +13,7 @@ class BaseException(Exception):
 class ValidationError(BaseException):
     """Exception raised when a Validator fails."""
 
-    pass
+    default_message = "Client configuration is invalid."
 
 
 class QueryNotValid(BaseException):

--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -34,10 +34,10 @@ class MissingToken(APIException):
     default_message = "No token is present. You must authenticate to use the client."
 
 
-class ExpiredToken(APIException):
-    """Exception raised when a previously valid token is expired."""
+class InvalidToken(APIException):
+    """Exception raised when a previously valid token is not valid anymore."""
 
-    default_message = "Used token is expired. You must authenticate again."
+    default_message = "Used token is not valid. You must authenticate again."
 
 
 class LockNotAcquired(BaseException):

--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -28,10 +28,10 @@ class APIException(BaseException):
     default_message = "A server error occurred"
 
 
-class PermissionDenied(APIException):
-    """Exception raised when a user doesn't have permission to perform this action."""
+class MissingToken(APIException):
+    """Exception raised when a client is used without prior authentication."""
 
-    default_message = "You do not have permission to perform this action"
+    default_message = "No token is present. You must authenticate to use the client."
 
 
 class LockNotAcquired(BaseException):

--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -34,7 +34,7 @@ class PermissionDenied(APIException):
     default_message = "You do not have permission to perform this action"
 
 
-class LockNotAcquired(Exception):
+class LockNotAcquired(BaseException):
     """Exception raised when a Lock() is required to run the function."""
 
     default_message = "System lock not acquired"

--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -34,6 +34,12 @@ class MissingToken(APIException):
     default_message = "No token is present. You must authenticate to use the client."
 
 
+class ExpiredToken(APIException):
+    """Exception raised when a previously valid token is expired."""
+
+    default_message = "Used token is expired. You must authenticate again."
+
+
 class LockNotAcquired(BaseException):
     """Exception raised when a Lock() is required to run the function."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,6 @@ from elmo.api.client import ElmoClient
 def client():
     """Create an ElmoClient with unlimited expiration time."""
     client = ElmoClient("https://example.com", "domain")
-    client._session_expire = 9999999999
     yield client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,9 @@ from elmo.api.client import ElmoClient
 
 @pytest.fixture
 def client():
-    """Create an ElmoClient with defaults."""
+    """Create an ElmoClient with unlimited expiration time."""
     client = ElmoClient("https://example.com", "domain")
+    client._session_expire = 9999999999
     yield client
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 import pytest
 import responses
+import time
 
 from requests.exceptions import HTTPError
 
@@ -63,6 +64,8 @@ def test_client_auth_success(server, client):
 
     assert client.auth("test", "test") == "00000000-0000-0000-0000-000000000000"
     assert client._session_id == "00000000-0000-0000-0000-000000000000"
+    # Ensures the token is valid for 10 minutes
+    assert int(client._session_expire) == int(time.time() + 60 * 10)
     assert len(server.calls) == 1
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,5 @@
 import pytest
 import responses
-import time
 
 from requests.exceptions import HTTPError
 
@@ -64,8 +63,6 @@ def test_client_auth_success(server, client):
 
     assert client.auth("test", "test") == "00000000-0000-0000-0000-000000000000"
     assert client._session_id == "00000000-0000-0000-0000-000000000000"
-    # Ensures the token is valid for 10 minutes
-    assert int(client._session_expire) == int(time.time() + 60 * 10)
     assert len(server.calls) == 1
 
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -41,25 +41,6 @@ def test_require_session_missing():
     assert "No token is present" in str(excinfo.value)
 
 
-def test_require_session_expired():
-    """Should fail if a session ID is expired."""
-
-    class TestClient(object):
-        def __init__(self):
-            # Session is available
-            self._session_id = "test"
-            self._session_expire = 1111111111
-
-        @require_session
-        def action(self):
-            return 42
-
-    client = TestClient()
-    with pytest.raises(ExpiredToken) as excinfo:
-        client.action()
-    assert "Used token is expired" in str(excinfo.value)
-
-
 def test_require_lock():
     """Should succeed if the lock has been acquired."""
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -2,7 +2,7 @@ import pytest
 
 from threading import Lock
 
-from elmo.api.exceptions import PermissionDenied, LockNotAcquired
+from elmo.api.exceptions import MissingToken, LockNotAcquired
 from elmo.api.decorators import require_session, require_lock
 
 
@@ -35,10 +35,8 @@ def test_require_session_missing():
             return 42
 
     client = TestClient()
-    with pytest.raises(PermissionDenied) as excinfo:
+    with pytest.raises(MissingToken) as excinfo:
         client.action()
-
-    assert str(excinfo.value) == "You do not have permission to perform this action."
 
 
 def test_require_lock():


### PR DESCRIPTION
### Overview

When a new session is created, the stored `session_id` is a short-lived token with 10 minutes expiration (at the time of writing). With this change, after the token is retrieved via `client.auth()` API call but it's used later when it's not valid anymore, the `@required_session` decorator detects `401 HTTPError` exceptions and translates these in `InvalidToken` exceptions.

The caller should catch the exception and repeat the authentication via `client.auth()`.

### Example

```python
try:
    client.arm()
except InvalidToken:
    client.auth("test", "test")
```