### PR TITLE
Improved Error Handling

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -207,7 +207,7 @@ class ElmoClient(object):
         if errors:
             invalid_sectors = ",".join(str(x) for x in errors)
             raise InvalidSector(
-                "Selected sectors doesn't exist: {}".format(invalid_sectors)
+                "Selected sectors don't exist: {}".format(invalid_sectors)
             )
 
         return True
@@ -271,7 +271,7 @@ class ElmoClient(object):
         if errors:
             invalid_sectors = ",".join(str(x) for x in errors)
             raise InvalidSector(
-                "Selected sectors doesn't exist: {}".format(invalid_sectors)
+                "Selected sectors don't exist: {}".format(invalid_sectors)
             )
 
         return True

--- a/elmo/api/decorators.py
+++ b/elmo/api/decorators.py
@@ -43,9 +43,20 @@ def require_lock(func):
         self = args[0]
         # If the Lock() acquisition succeed it means a locking is not occurring
         # and so bail-out the execution (and release the lock).
+        # TODO: Lock() state must be moved outside of this client, so that
+        # it represents a stateless client.
         if not self._lock.locked():
             raise LockNotAcquired("A lock must be acquired via `lock()` method.")
         else:
-            return func(*args, **kwargs)
+            try:
+                return func(*args, **kwargs)
+            except HTTPError as err:
+                # 403: Method has been called without obtaining the server lock
+                if err.response.status_code == 403:
+                    self._lock.release()
+                    raise LockNotAcquired(
+                        "A lock must be acquired via `lock()` method."
+                    )
+                raise err
 
     return func_wrapper

--- a/elmo/api/decorators.py
+++ b/elmo/api/decorators.py
@@ -43,8 +43,7 @@ def require_lock(func):
         self = args[0]
         # If the Lock() acquisition succeed it means a locking is not occurring
         # and so bail-out the execution (and release the lock).
-        if self._lock.acquire(False):
-            self._lock.release()
+        if not self._lock.locked():
             raise LockNotAcquired("A lock must be acquired via `lock()` method.")
         else:
             return func(*args, **kwargs)

--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -56,3 +56,9 @@ class CodeError(APIException):
     """Exception raised when used panel code is not correct."""
 
     default_message = "Digited panel code is not correct"
+
+
+class InvalidSector(APIException):
+    """Exception raised when armed/disarmed sector doesn't exist."""
+
+    default_message = "Selected sector doesn't exist."

--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -28,6 +28,12 @@ class APIException(BaseException):
     default_message = "A server error occurred"
 
 
+class CredentialError(APIException):
+    """Exception raise when used credentials are not correct."""
+
+    default_message = "Username or password are not correct"
+
+
 class MissingToken(APIException):
     """Exception raised when a client is used without prior authentication."""
 

--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -29,7 +29,7 @@ class APIException(BaseException):
 
 
 class CredentialError(APIException):
-    """Exception raise when used credentials are not correct."""
+    """Exception raised when used credentials are not correct."""
 
     default_message = "Username or password are not correct"
 
@@ -50,3 +50,9 @@ class LockNotAcquired(BaseException):
     """Exception raised when a Lock() is required to run the function."""
 
     default_message = "System lock not acquired"
+
+
+class CodeError(APIException):
+    """Exception raised when used panel code is not correct."""
+
+    default_message = "Digited panel code is not correct"

--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -52,6 +52,12 @@ class LockNotAcquired(BaseException):
     default_message = "System lock not acquired"
 
 
+class LockError(APIException):
+    """Exception raised when it's not possible to obtain the Lock()."""
+
+    default_message = "Unable to obtain the Lock()."
+
+
 class CodeError(APIException):
     """Exception raised when used panel code is not correct."""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -200,7 +200,7 @@ def test_client_lock(server, client, mocker):
         {
             "Poller": {"Poller": 1, "Panel": 1},
             "CommandId": 5,
-            "Successful": True,
+            "Successful": true
         }
     ]"""
     server.add(
@@ -220,7 +220,7 @@ def test_client_lock_forbidden(server, client, mocker):
         {
             "Poller": {"Poller": 1, "Panel": 1},
             "CommandId": 5,
-            "Successful": False,
+            "Successful": false
         }
     ]"""
     server.add(
@@ -255,7 +255,16 @@ def test_client_lock_unknown_error(server, client, mocker):
 
 def test_client_lock_calls_unlock(server, client, mocker):
     """Should call unlock() when exiting from the context."""
-    server.add(responses.POST, "https://example.com/api/panel/syncLogin")
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": true
+        }
+    ]"""
+    server.add(
+        responses.POST, "https://example.com/api/panel/syncLogin", body=html, status=200
+    )
     mocker.patch.object(client, "unlock")
     client._session_id = "test"
 
@@ -271,7 +280,7 @@ def test_client_unlock(server, client):
         {
             "Poller": {"Poller": 1, "Panel": 1},
             "CommandId": 5,
-            "Successful": True,
+            "Successful": true
         }
     ]"""
     server.add(
@@ -304,7 +313,7 @@ def test_client_unlock_fails_forbidden(server, client):
         {
             "Poller": {"Poller": 1, "Panel": 1},
             "CommandId": 5,
-            "Successful": False,
+            "Successful": false
         }
     ]"""
     server.add(
@@ -329,7 +338,7 @@ def test_client_unlock_fails_unexpected_error(server, client):
         {
             "Poller": {"Poller": 1, "Panel": 1},
             "CommandId": 5,
-            "Successful": False,
+            "Successful": false
         }
     ]"""
     server.add(
@@ -353,7 +362,7 @@ def test_client_arm(server, client):
         {
             "Poller": {"Poller": 1, "Panel": 1},
             "CommandId": 5,
-            "Successful": True,
+            "Successful": true
         }
     ]"""
     server.add(
@@ -380,7 +389,7 @@ def test_client_arm_sectors(server, client):
         {
             "Poller": {"Poller": 1, "Panel": 1},
             "CommandId": 5,
-            "Successful": True,
+            "Successful": true
         }
     ]"""
     server.add(
@@ -453,7 +462,7 @@ def test_client_disarm(server, client):
         {
             "Poller": {"Poller": 1, "Panel": 1},
             "CommandId": 5,
-            "Successful": True,
+            "Successful": true
         }
     ]"""
     server.add(
@@ -480,7 +489,7 @@ def test_client_disarm_sectors(server, client):
         {
             "Poller": {"Poller": 1, "Panel": 1},
             "CommandId": 5,
-            "Successful": True,
+            "Successful": true
         }
     ]"""
     server.add(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,7 @@ from elmo.api.exceptions import (
     QueryNotValid,
     CredentialError,
     InvalidToken,
+    CodeError,
 )
 
 
@@ -214,8 +215,8 @@ def test_client_lock(server, client, mocker):
     assert len(server.calls) == 1
 
 
-def test_client_lock_forbidden(server, client, mocker):
-    """Should raise an Exception if credentials are not correct."""
+def test_client_lock_wrong_code(server, client, mocker):
+    """Should raise a CodeError if inserted code is not correct."""
     html = """[
         {
             "Poller": {"Poller": 1, "Panel": 1},
@@ -224,12 +225,12 @@ def test_client_lock_forbidden(server, client, mocker):
         }
     ]"""
     server.add(
-        responses.POST, "https://example.com/api/panel/syncLogin", body=html, status=403
+        responses.POST, "https://example.com/api/panel/syncLogin", body=html, status=200
     )
     mocker.patch.object(client, "unlock")
     client._session_id = "test"
 
-    with pytest.raises(HTTPError):
+    with pytest.raises(CodeError):
         with client.lock("test"):
             pass
     assert len(server.calls) == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,7 @@ from elmo.api.exceptions import (
     InvalidToken,
     CodeError,
     InvalidSector,
+    LockError,
 )
 
 
@@ -232,6 +233,18 @@ def test_client_lock_wrong_code(server, client, mocker):
     client._session_id = "test"
 
     with pytest.raises(CodeError):
+        with client.lock("test"):
+            pass
+    assert len(server.calls) == 1
+
+
+def test_client_lock_called_twice(server, client, mocker):
+    """Should raise a CodeError if Lock() is called twice."""
+    server.add(responses.POST, "https://example.com/api/panel/syncLogin", status=403)
+    mocker.patch.object(client, "unlock")
+    client._session_id = "test"
+
+    with pytest.raises(LockError):
         with client.lock("test"):
             pass
     assert len(server.calls) == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,6 +11,7 @@ from elmo.api.exceptions import (
     CredentialError,
     InvalidToken,
     CodeError,
+    InvalidSector,
 )
 
 
@@ -441,6 +442,28 @@ def test_client_arm_fails_missing_session(server, client):
     assert len(server.calls) == 1
 
 
+def test_client_arm_fails_wrong_sector(server, client):
+    """Should fail if a not existing sector is used."""
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": false
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body=html,
+        status=200,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
+    with pytest.raises(InvalidSector):
+        assert client.arm([200])
+
+
 def test_client_arm_fails_unknown_error(server, client):
     """Should fail if an unknown error happens."""
     server.add(
@@ -539,6 +562,28 @@ def test_client_disarm_fails_missing_session(server, client):
     with pytest.raises(InvalidToken):
         client.disarm()
     assert len(server.calls) == 1
+
+
+def test_client_disarm_fails_wrong_sector(server, client):
+    """Should fail if a not existing sector is used."""
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": false
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body=html,
+        status=200,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
+    with pytest.raises(InvalidSector):
+        assert client.disarm([200])
 
 
 def test_client_disarm_fails_unknown_error(server, client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,7 +5,7 @@ from requests.exceptions import HTTPError
 
 from elmo import query
 from elmo.api.client import ElmoClient
-from elmo.api.exceptions import LockNotAcquired, QueryNotValid
+from elmo.api.exceptions import LockNotAcquired, QueryNotValid, CredentialError
 
 
 def test_client_constructor_default():
@@ -75,11 +75,10 @@ def test_client_auth_forbidden(server, client):
         status=403,
     )
 
-    with pytest.raises(HTTPError) as excinfo:
+    with pytest.raises(CredentialError):
         client.auth("test", "test")
     assert client._session_id is None
     assert len(server.calls) == 1
-    assert "403 Client Error: Forbidden" in str(excinfo.value)
 
 
 def test_client_auth_unknown_error(server, client):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -97,3 +97,23 @@ def test_require_lock_fails():
     client = TestClient()
     with pytest.raises(LockNotAcquired):
         client.action()
+
+
+def test_require_lock_not_valid():
+    """Should fail if the obtained lock is not valid anymore (API returns 401)."""
+
+    class TestClient(object):
+        def __init__(self):
+            # Lock attribute
+            self._lock = Lock()
+
+        @require_lock
+        def action(self):
+            # Raise a 403 to emulate lack of a valid Lock()
+            r = Response()
+            r.status_code = 403
+            raise HTTPError(response=r)
+
+    client = TestClient()
+    with pytest.raises(LockNotAcquired):
+        client.action()


### PR DESCRIPTION
### Overview

The previous version was relying only on `HTTPError` exception from the `requests` package. To make the code more generic and to raise meaningful exceptions, every method and decorator handles client/server errors.

The following exceptions have been added:
- `CredentialError`: when incorrect username/password are used
- `LockError`: when there is a race condition with another application, while trying to obtain the lock
- `CodeError`: when the used `code` is not correct
- `InvalidSector`: when using `arm()` or `disarm()`, an invalid sector is used

Cases that are covered are the following:
- Acquire the lock when it has been acquired already by someone else
- Incorrect username or password
- Incorrect code
- Call a method without obtaining the lock
- Call any method when a token is expired / is invalid
- Call arm/disarm for an invalid area
- Call the lock when it has been obtained already
- Call unlock without calling lock
- Any method call that requires a lock, but is called without obtaining the lock