### PR TITLE
[core/client] Ensure unlock() is called even if an exception is raised in the block

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -119,8 +119,10 @@ class ElmoClient(object):
             raise CodeError
 
         self._lock.acquire()
-        yield self
-        self.unlock()
+        try:
+            yield self
+        finally:
+            self.unlock()
 
     @require_session
     @require_lock


### PR DESCRIPTION
### Overview

Closes #56 

With the previous behavior, any kind of exception raised in a `with client.lock(code):` block was preventing the `Lock()` from being released. The change ensures that `unlock()` is called in any case, behaving as a `try-finally` block.