### PR TITLE
Implement long-polling to retrieve state updates

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -89,6 +89,46 @@ class ElmoClient(object):
 
         return self._session_id
 
+    @require_session
+    def poll(self):
+        """Use a long-polling API to identify when something changes in the
+        system. Calling this method blocks the thread for 15 seconds, waiting
+        for a backend response that happens only when the alarm system status
+        changes. Don't call this method from your main thread otherwise the
+        application hangs.
+
+        When the API returns that something is changed, you must call the
+        `client.check()` to update your identifiers. Missing this step means
+        that the next time you will call `client.poll()` the API returns immediately
+        with an old result.
+
+        Raises:
+            HTTPError: if there is an error raised by the API (not 2xx response).
+        Returns:
+            A dictionary that includes what items have been changed. The following
+            structure means that `areas` are not changed, while inputs are:
+                {
+                    "areas": False,
+                    "inputs": True,
+                }
+        """
+        payload = {
+            "sessionId": self._session_id,
+            "Areas": self._latestEntryId[q.SECTORS],
+            "Inputs": self._latestEntryId[q.INPUTS],
+            "CanElevate": "1",
+            "ConnectionStatus": "1",
+        }
+        response = self._session.post(self._router.update, data=payload)
+        response.raise_for_status()
+
+        state = response.json()
+        return {
+            "has_changes": state["HasChanges"],
+            "areas": state["Areas"],
+            "inputs": state["Inputs"],
+        }
+
     @contextmanager
     @require_session
     def lock(self, code):

--- a/elmo/api/router.py
+++ b/elmo/api/router.py
@@ -26,6 +26,10 @@ class Router(object):
         return "{}/api/strings".format(self._base_url)
 
     @property
+    def update(self):
+        return "{}/api/updates".format(self._base_url)
+
+    @property
     def lock(self):
         return "{}/api/panel/syncLogin".format(self._base_url)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -197,6 +197,131 @@ def test_client_auth_with_domain(server):
     assert server.calls[0].request.params["domain"] == "domain"
 
 
+def test_client_poll(server, client):
+    """Should leverage long-polling endpoint to grab the status."""
+    html = """
+        {
+            "ConnectionStatus": false,
+            "CanElevate": false,
+            "LoggedIn": false,
+            "LoginInProgress": false,
+            "Areas": false,
+            "Events": false,
+            "Inputs": false,
+            "Outputs": false,
+            "Anomalies": false,
+            "ReadStringsInProgress": false,
+            "ReadStringPercentage": 0,
+            "Strings": 0,
+            "ManagedAccounts": false,
+            "Temperature": false,
+            "StatusAdv": false,
+            "Images": false,
+            "AdditionalInfoSupported": true,
+            "HasChanges": false
+        }
+    """
+    server.add(responses.POST, "https://example.com/api/updates", body=html, status=200)
+    client._session_id = "test"
+
+    state = client.poll()
+    assert len(state.keys()) == 3
+    assert state["has_changes"] is False
+    assert state["inputs"] is False
+    assert state["areas"] is False
+
+
+def test_client_poll_with_changes(server, client):
+    """Should return a dict with updated states."""
+    html = """
+        {
+            "ConnectionStatus": false,
+            "CanElevate": false,
+            "LoggedIn": false,
+            "LoginInProgress": false,
+            "Areas": true,
+            "Events": false,
+            "Inputs": true,
+            "Outputs": false,
+            "Anomalies": false,
+            "ReadStringsInProgress": false,
+            "ReadStringPercentage": 0,
+            "Strings": 0,
+            "ManagedAccounts": false,
+            "Temperature": false,
+            "StatusAdv": false,
+            "Images": false,
+            "AdditionalInfoSupported": true,
+            "HasChanges": true
+        }
+    """
+    server.add(responses.POST, "https://example.com/api/updates", body=html, status=200)
+    client._session_id = "test"
+
+    state = client.poll()
+    assert len(state.keys()) == 3
+    assert state["has_changes"] is True
+    assert state["inputs"] is True
+    assert state["areas"] is True
+
+
+def test_client_poll_with_updated_ids(server, client):
+    """Should use internal IDs to make the call."""
+    html = """
+        {
+            "ConnectionStatus": false,
+            "CanElevate": false,
+            "LoggedIn": false,
+            "LoginInProgress": false,
+            "Areas": true,
+            "Events": false,
+            "Inputs": true,
+            "Outputs": false,
+            "Anomalies": false,
+            "ReadStringsInProgress": false,
+            "ReadStringPercentage": 0,
+            "Strings": 0,
+            "ManagedAccounts": false,
+            "Temperature": false,
+            "StatusAdv": false,
+            "Images": false,
+            "AdditionalInfoSupported": true,
+            "HasChanges": true
+        }
+    """
+    server.add(responses.POST, "https://example.com/api/updates", body=html, status=200)
+    client._session_id = "test"
+    client._latestEntryId = {
+        query.SECTORS: 42,
+        query.INPUTS: 4242,
+    }
+
+    client.poll()
+    assert len(server.calls) == 1
+    body = server.calls[0].request.body.split("&")
+    assert "sessionId=test" in body
+    assert "Areas=42" in body
+    assert "Inputs=4242" in body
+    assert "CanElevate=1" in body
+    assert "ConnectionStatus=1" in body
+
+
+def test_client_poll_unknown_error(server, client):
+    """Should raise an Exception for unknown status code."""
+    server.add(
+        responses.POST,
+        "https://example.com/api/updates",
+        body="Server Error",
+        status=500,
+    )
+
+    client._session_id = "test"
+
+    with pytest.raises(HTTPError):
+        client.poll()
+    assert len(server.calls) == 1
+
+
 def test_client_lock(server, client, mocker):
     """Should acquire a lock if credentials are properly provided."""
     html = """[

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -759,6 +759,8 @@ def test_client_get_sectors_status(server, client, sectors_json, mocker):
     assert sectors_disarmed == [
         {"element": 3, "id": 3, "index": 2, "name": "Kitchen"},
     ]
+    # Element 4 is filtered out but the query must store that value
+    assert client._latestEntryId[query.SECTORS] == 4
 
 
 def test_client_get_inputs(server, client, inputs_json, mocker):
@@ -783,6 +785,8 @@ def test_client_get_inputs(server, client, inputs_json, mocker):
     assert inputs_wait == [
         {"element": 3, "id": 3, "index": 2, "name": "Door entryway"},
     ]
+    # Element 4 is filtered out but the query must store that value
+    assert client._latestEntryId[query.INPUTS] == 4
 
 
 def test_client_query_not_valid(client):


### PR DESCRIPTION
### Overview

Econnect API implements a long-polling in `/api/updates` endpoint. This change leverages this API to understand when the state is updated, so that it can trigger a `client.check()` call to get the latest. It prevents making a random polling (e.g. every 5 seconds), while triggering an update only when something changes.

At the time of writing, this API blocks the thread for 15 seconds, or unless something changes. To make it work, the client has to store inputs and areas IDs to get an update. This is not ideal but that's what the API offers.