### PR TITLE
Remove check() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,6 @@ with client.lock("secret-code") as c:
 # Query the system
 sectors_armed, sectors_disarmed = client.query(query.SECTORS)
 inputs_alerted, inputs_wait = client.query(query.INPUTS)
-
-# Or use the shortcut
-status = client.check()
-
-# Returns:
-# {
-#   "sectors_armed": [{"id": 0, "name": "Entryway", "element": 1, "index": 0}, ...],
-#   "sectors_disarmed": [{"id": 1, "name": "Kitchen", "element": 2, "index": 1}, ...],
-#   "inputs_alerted": [{"id": 0, "name": "Door", "element": 3, "index": 0}, ...],
-#   "inputs_wait": [{"id": 1, "name": "Window", "element": 4, "index": 1}, ...],
-# }
 ```
 
 The access token is valid for 10 minutes, after which, you need to authenticate again to

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -521,37 +521,3 @@ class ElmoClient(object):
                     not_active.append(item)
 
         return active, not_active
-
-    @require_session
-    def check(self):
-        """Check the Elmo System to get the status of armed or disarmed sectors or inputs
-        that are in alerted state or that are waiting. This method checks:
-            * If any sector is in alerted state
-            * If the alarm for each sector is armed or disarmed
-            * If the alarm for each input is in alerted state or not
-
-        This method is considered a shortcut that calls `client.query()` with `SECTORS`
-        and `INPUTS` queries.
-
-        Raises:
-            HTTPError: if there is an error raised by the API (not 2xx response).
-        Returns:
-            A `dict` object that includes all the above information. The `dict` is in
-            the following format:
-            {
-              "sectors_armed": [{"id": 0, "name": "Entryway", "element": 1, "index": 0}, ...],
-              "sectors_disarmed": [{"id": 1, "name": "Kitchen", "element": 2, "index": 1}, ...],
-              "inputs_alerted": [{"id": 0, "name": "Door", "element": 3, "index": 0}, ...],
-              "inputs_wait": [{"id": 1, "name": "Window", "element": 4, "index": 1}, ...],
-            }
-        """
-        # Retrieve sectors and inputs
-        sectors_armed, sectors_disarmed = self.query(q.SECTORS)
-        inputs_alerted, inputs_wait = self.query(q.INPUTS)
-
-        return {
-            "sectors_armed": sectors_armed,
-            "sectors_disarmed": sectors_disarmed,
-            "inputs_alerted": inputs_alerted,
-            "inputs_wait": inputs_wait,
-        }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1198,37 +1198,3 @@ def test_client_query_error(server, client, mocker):
     mocker.patch.object(client, "_get_descriptions")
     with pytest.raises(HTTPError):
         client.query(query.SECTORS)
-
-
-def test_client_check_success(server, client, sectors_json, inputs_json, mocker):
-    """Should check the global status of an Elmo System. This test runs
-    as a full test and doesn't mock the `client.query()` method. Without
-    mocks, the contract from `client.query()` is verified.
-    """
-    # Check depends on querying sectors/inputs endpoints
-    server.add(
-        responses.POST, "https://example.com/api/areas", body=sectors_json, status=200
-    )
-    server.add(
-        responses.POST, "https://example.com/api/inputs", body=inputs_json, status=200
-    )
-    mocker.patch.object(client, "_get_descriptions")
-    # Mock descriptions list
-    client._get_descriptions.return_value = {
-        9: {0: "Living Room", 1: "Bedroom", 2: "Kitchen", 3: "Entryway"},
-        10: {0: "Alarm", 1: "Window kitchen", 2: "Door entryway", 3: "Window bathroom"},
-    }
-    client._session_id = "test"
-    results = client.check()
-    assert results == {
-        "sectors_armed": [
-            {"element": 1, "id": 1, "index": 0, "name": "Living Room"},
-            {"element": 2, "id": 2, "index": 1, "name": "Bedroom"},
-        ],
-        "sectors_disarmed": [{"element": 3, "id": 3, "index": 2, "name": "Kitchen"}],
-        "inputs_alerted": [
-            {"element": 1, "id": 1, "index": 0, "name": "Alarm"},
-            {"element": 2, "id": 2, "index": 1, "name": "Window kitchen"},
-        ],
-        "inputs_wait": [{"element": 3, "id": 3, "index": 2, "name": "Door entryway"}],
-    }


### PR DESCRIPTION
### Overview

This change removes the `client.check()` API. The rationale is that this shortcut is considered a duplicate and violates the `ElmoClient` class responsibility. This class must stay lightweight without any extra logic other than handling the connection and make API calls.