### PR TITLE
query() API returns also "last_id" field; items are grouped under "sectors" or "inputs" keys

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -488,8 +488,10 @@ class ElmoClient(object):
         # Query detection
         if query == q.SECTORS:
             endpoint = self._router.sectors
+            key_group = "sectors"
         elif query == q.INPUTS:
             endpoint = self._router.inputs
+            key_group = "inputs"
         else:
             # Bail-out if the query is not recognized
             raise QueryNotValid()
@@ -506,6 +508,10 @@ class ElmoClient(object):
         # are never excluded.
         entries = response.json()
         items = {}
+        result = {
+            "last_id": entries[-1]["Id"],
+            key_group: items,
+        }
         for entry in entries:
             if entry["InUse"]:
                 item = {
@@ -518,4 +524,4 @@ class ElmoClient(object):
 
                 items[entry.get("Index")] = item
 
-        return items
+        return result

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1129,15 +1129,30 @@ def test_client_get_sectors_status(server, client, sectors_json, mocker):
     assert client._get_descriptions.called is True
     assert len(server.calls) == 1
     assert sectors == {
-        0: {
-            "element": 1,
-            "id": 1,
-            "index": 0,
-            "excluded": False,
-            "name": "Living Room",
+        "last_id": 4,
+        "sectors": {
+            0: {
+                "element": 1,
+                "id": 1,
+                "index": 0,
+                "excluded": False,
+                "name": "Living Room",
+            },
+            1: {
+                "element": 2,
+                "id": 2,
+                "index": 1,
+                "excluded": False,
+                "name": "Bedroom",
+            },
+            2: {
+                "element": 3,
+                "id": 3,
+                "index": 2,
+                "excluded": False,
+                "name": "Kitchen",
+            },
         },
-        1: {"element": 2, "id": 2, "index": 1, "excluded": False, "name": "Bedroom"},
-        2: {"element": 3, "id": 3, "index": 2, "excluded": False, "name": "Kitchen"},
     }
 
 
@@ -1157,20 +1172,23 @@ def test_client_get_inputs(server, client, inputs_json, mocker):
     assert client._get_descriptions.called is True
     assert len(server.calls) == 1
     assert inputs == {
-        0: {"element": 1, "id": 1, "index": 0, "excluded": False, "name": "Alarm"},
-        1: {
-            "element": 2,
-            "id": 2,
-            "index": 1,
-            "excluded": False,
-            "name": "Window kitchen",
-        },
-        2: {
-            "element": 3,
-            "id": 3,
-            "index": 2,
-            "excluded": True,
-            "name": "Door entryway",
+        "last_id": 4,
+        "inputs": {
+            0: {"element": 1, "id": 1, "index": 0, "excluded": False, "name": "Alarm"},
+            1: {
+                "element": 2,
+                "id": 2,
+                "index": 1,
+                "excluded": False,
+                "name": "Window kitchen",
+            },
+            2: {
+                "element": 3,
+                "id": 3,
+                "index": 2,
+                "excluded": True,
+                "name": "Door entryway",
+            },
         },
     }
 


### PR DESCRIPTION
### Overview

- Updates `client.query()` API to return also a `last_id` that is needed to use the long-polling API (it will be used by another component).
- Items are grouped under `sectors` or `inputs` keys

Returned object has the following structure:
```python
{
"last_id": 4,
"sectors": {
    0: {
        "element": 1,
        "id": 1,
        "index": 0,
        "excluded": False,
        "name": "Living Room",
    },
    1: {
        "element": 2,
        "id": 2,
        "index": 1,
        "excluded": False,
        "name": "Bedroom",
    },
    2: {
        "element": 3,
        "id": 3,
        "index": 2,
        "excluded": False,
        "name": "Kitchen",
    },
}

# or

{
"last_id": 4,
"inputs": {
    0: {
        "element": 1,
        "id": 1,
        "index": 0,
        "excluded": False,
        "name": "Living Room",
    },
    1: {
        "element": 2,
        "id": 2,
        "index": 1,
        "excluded": False,
        "name": "Bedroom",
    },
    2: {
        "element": 3,
        "id": 3,
        "index": 2,
        "excluded": False,
        "name": "Kitchen",
    },
}
```