### PR TITLE
feat!: drop support for EOL Python versions; support Python 3.8 -> 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Through a generic configuration, the client allows:
 
 ## Requirements
 
-* Python 3.6+
+* Python 3.8+
 * `requests`
 
 ## Getting Started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "elmo"
 dynamic = ["version"]
 description = 'API adapter used to control programmatically an Elmo alarm system'
 readme = "README.md"
-requires-python = ">=3.5"
+requires-python = ">=3.8"
 license = "Apache-2.0"
 keywords = []
 authors = [
@@ -16,11 +16,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.5",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
     lint
-    py3.6
-    py3.7
     py3.8
     py3.9
+    py3.10
+    py3.11
 
 [testenv]
 allowlist_externals = pytest


### PR DESCRIPTION
### Related Issues

- Closes #84 

### Proposed Changes:

Add support only for the following Python versions:
- 3.8
- 3.9
- 3.10
- 3.11

### Testing:

`tox` test matrix has been updated.

### Extra Notes (optional):

EOL versions have been dropped.

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
