### PR TITLE
feat(client): add DEBUG logging to `ElmoClient`

### DIFF
--- a/src/elmo/utils.py
+++ b/src/elmo/utils.py
@@ -31,3 +31,19 @@ def _filter_data(data, key, status):
         _LOGGER.error(f"Utils | Error filtering {key} query: {err}")
         raise err
     return filtered_data
+
+
+def _sanitize_session_id(session_id):
+    """Obfuscates a session ID, preserving the first 8 characters and dashes.
+
+    This function retains the first 8 characters of the given session ID, and replaces
+    the subsequent characters with 'X', except for dashes, which are preserved.
+
+    Args:
+        session_id (str): The session ID to be sanitized.
+
+    Returns:
+        str: The sanitized session ID.
+    """
+    sanitized = session_id[:8] + "".join("-" if char == "-" else "X" for char in session_id[8:])
+    return sanitized

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from elmo.utils import _filter_data
+from elmo.utils import _filter_data, _sanitize_session_id
 
 
 def test_filter_data_empty_data():
@@ -66,3 +66,10 @@ def test_filter_data_key_error():
     status = True
     with pytest.raises(KeyError):
         _filter_data(data, key, status)
+
+
+def test_sanitize_identifier():
+    """Ensure session ID are obfuscated for debug purposes."""
+    assert _sanitize_session_id("0fb182e9-474c-ca1c-f60c-ed203dbb26aa") == "0fb182e9-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    assert _sanitize_session_id("abcdefgh-ijkl-mnop-qrst-uvwxyz012345") == "abcdefgh-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+    assert _sanitize_session_id("12345678-90ab-cdef-ghij-klmnopqrstuv") == "12345678-XXXX-XXXX-XXXX-XXXXXXXXXXXX"


### PR DESCRIPTION
### Related Issues

- Closes #95 

### Proposed Changes:

This change includes logging `DEBUG` for all `ElmoClient` commands. `AlarmDevice` logs only raised errors as it is a simple proxy to the underlying client. What is logged in `ElmoClient` can be used in tests to fix any troubles in `AlarmDevice`. If such statement is proved to not be right, then we'll adjust with further changes.

### Testing:

This PR includes a logger test to verify that `SessionID` is logged but sanitized. Such test must not be removed otherwise sessions will be leaked in users' logs.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
