### PR TITLE
fix(client): sector/input name defaults to `Unknown` if the main unit is out of sync with the cloud

### DIFF
--- a/src/elmo/api/client.py
+++ b/src/elmo/api/client.py
@@ -564,13 +564,19 @@ class ElmoClient:
         try:
             for entry in entries:
                 if entry["InUse"]:
+                    # Address potential data inconsistency between cloud data and main unit.
+                    # In some installations, they may be out of sync, resulting in the cloud
+                    # providing a sector/input that doesn't actually exist in the main unit.
+                    # To handle this, we default the name to "Unknown" if its description
+                    # isn't found in the cloud data to prevent KeyError.
+                    name = descriptions[query].get(entry["Index"], "Unknown")
                     item = {
                         "id": entry.get("Id"),
                         "index": entry.get("Index"),
                         "element": entry.get("Element"),
                         "excluded": entry.get("Excluded", False),
                         "status": entry.get(status, False),
-                        "name": descriptions[query][entry.get("Index")],
+                        "name": name,
                     }
 
                     items[entry.get("Index")] = item

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1421,6 +1421,130 @@ def test_client_get_inputs_status(server, mocker):
     }
 
 
+def test_client_get_sectors_missing_area(server, mocker):
+    """Should set an Unknown `sector` name if the description is missing.
+    Regression test for: https://github.com/palazzem/econnect-python/issues/91"""
+    html = """[
+       {
+           "Active": true,
+           "ActivePartial": false,
+           "Max": false,
+           "Activable": true,
+           "ActivablePartial": false,
+           "InUse": true,
+           "Id": 1,
+           "Index": 0,
+           "Element": 1,
+           "CommandId": 0,
+           "InProgress": false
+       },
+       {
+           "Active": true,
+           "ActivePartial": false,
+           "Max": false,
+           "Activable": true,
+           "ActivablePartial": false,
+           "InUse": true,
+           "Id": 2,
+           "Index": 1,
+           "Element": 2,
+           "CommandId": 0,
+           "InProgress": false
+       }
+    ]"""
+    server.add(responses.POST, "https://example.com/api/areas", body=html, status=200)
+    client = ElmoClient(base_url="https://example.com", domain="domain")
+    client._session_id = "test"
+    mocker.patch.object(client, "_get_descriptions")
+    client._get_descriptions.return_value = {
+        9: {0: "Living Room"},
+    }
+    # Test
+    sectors = client.query(query.SECTORS)
+    assert sectors == {
+        "last_id": 2,
+        "sectors": {
+            0: {
+                "element": 1,
+                "id": 1,
+                "index": 0,
+                "status": True,
+                "excluded": False,
+                "name": "Living Room",
+            },
+            1: {
+                "element": 2,
+                "id": 2,
+                "index": 1,
+                "status": True,
+                "excluded": False,
+                "name": "Unknown",
+            },
+        },
+    }
+
+
+def test_client_get_inputs_missing_area(server, mocker):
+    """Should set an Unknown `input` name if the description is missing.
+    Regression test for: https://github.com/palazzem/econnect-python/issues/91"""
+    html = """[
+       {
+           "Alarm": true,
+           "MemoryAlarm": false,
+           "Excluded": false,
+           "InUse": true,
+           "IsVideo": false,
+           "Id": 1,
+           "Index": 0,
+           "Element": 1,
+           "CommandId": 0,
+           "InProgress": false
+       },
+       {
+           "Alarm": true,
+           "MemoryAlarm": false,
+           "Excluded": false,
+           "InUse": true,
+           "IsVideo": false,
+           "Id": 2,
+           "Index": 1,
+           "Element": 2,
+           "CommandId": 0,
+           "InProgress": false
+       }
+    ]"""
+    server.add(responses.POST, "https://example.com/api/inputs", body=html, status=200)
+    client = ElmoClient(base_url="https://example.com", domain="domain")
+    client._session_id = "test"
+    mocker.patch.object(client, "_get_descriptions")
+    client._get_descriptions.return_value = {
+        10: {0: "Alarm"},
+    }
+    # Test
+    inputs = client.query(query.INPUTS)
+    assert inputs == {
+        "last_id": 2,
+        "inputs": {
+            0: {
+                "element": 1,
+                "id": 1,
+                "index": 0,
+                "status": True,
+                "excluded": False,
+                "name": "Alarm",
+            },
+            1: {
+                "element": 2,
+                "id": 2,
+                "index": 1,
+                "status": True,
+                "excluded": False,
+                "name": "Unknown",
+            },
+        },
+    }
+
+
 def test_client_query_not_valid(client):
     """Should raise QueryNotValid if the query is not recognized."""
     client = ElmoClient(base_url="https://example.com", domain="domain")


### PR DESCRIPTION
### Related Issues

- Closes #91 

### Proposed Changes:

There was an issue where Home Assistant (HA) integration would crash if there was a data inconsistency between the main unit and the cloud. Specifically, when a sector or input was indicated as active and in use by the cloud, but it was not truly active and did not have a corresponding description.

This inconsistency led to a `KeyError` being raised when the system tried to fetch the description for the said active sector or input from the cloud data.

To handle this, we've implemented a fix that defaults the description to "Unknown" in cases where it is not found in the cloud data. This ensures the HA integration continues to function smoothly without crashing, even in the face of such data discrepancies.

### Testing:

A regression test has been added both for sectors and inputs.

### Extra Notes (optional):

None.

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
