### PR TITLE
package: ensure project name is econnect-python; pytest python PATH is `src`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "elmo"
+name = "econnect-python"
 dynamic = ["version"]
 description = 'API adapter used to control programmatically an Elmo alarm system'
 readme = "README.md"
@@ -45,8 +45,8 @@ lint = [
 ]
 
 all = [
-  "elmo[dev]",
-  "elmo[lint]",
+  "econnect-python[dev]",
+  "econnect-python[lint]",
 ]
 
 [project.urls]
@@ -59,3 +59,6 @@ path = "src/elmo/__about__.py"
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.pytest.ini_options]
+pythonpath = "src"


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

Ensure the project is called `econnect-python` instead of `elmo` as it is the name of the python package in pypi.

### Testing:

n/a

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
