### PR TITLE
fix(builder): update Hatch build target to include `elmo` package

### DIFF
--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -1,0 +1,43 @@
+name: 'Building'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  econnect:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: |
+            3.11
+
+      - name: Upgrade pip and install required tools
+        run: |
+          pip install --upgrade pip
+          pip install hatch
+
+      - name: Build the package
+        run: hatch build
+
+      - name: Install the package
+        run: pip install dist/*.tar.gz
+
+      - name: Test if the package is built correctly
+        run: python -c "import elmo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ Documentation = "https://github.com/palazzem/econnect-python#readme"
 Issues = "https://github.com/palazzem/econnect-python/issues"
 Source = "https://github.com/palazzem/econnect-python"
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/elmo"]
+
 [tool.hatch.version]
 path = "src/elmo/__about__.py"
 

--- a/src/elmo/__about__.py
+++ b/src/elmo/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2023-present Emanuele Palazzetti <emanuele.palazzetti@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:

The latest release used `hatch` to build Python targets. Unfortunately the targets configuration was missing, and the entire project has been shipped as `src/elmo` without defining `elmo` as a package. This generates import errors in projects using this library.

This change now ships a Python package with the right `hatch` configuration.

### Testing:

"Building" GitHub actions now verifies if the package is built correctly.

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
