### PR TITLE
feat(client): implement get_status() to retrieve the main unit anomalies/alarms/tampering

### DIFF
--- a/src/elmo/api/router.py
+++ b/src/elmo/api/router.py
@@ -32,6 +32,10 @@ class Router:
         return "{}/api/updates".format(self._base_url)
 
     @property
+    def status(self):
+        return "{}/api/statusadv".format(self._base_url)
+
+    @property
     def lock(self):
         return "{}/api/panel/syncLogin".format(self._base_url)
 

--- a/src/elmo/utils.py
+++ b/src/elmo/utils.py
@@ -1,4 +1,6 @@
 import logging
+import re
+from functools import lru_cache
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,3 +49,42 @@ def _sanitize_session_id(session_id):
     """
     sanitized = session_id[:8] + "".join("-" if char == "-" else "X" for char in session_id[8:])
     return sanitized
+
+
+@lru_cache(maxsize=42)
+def _camel_to_snake_case(name):
+    """
+    Convert a CamelCase string to snake_case.
+
+    This function implements an LRU cache to avoid doing the operation multiple times. As
+    it is used with a very limited set of inputs, the cache size is set to 42 as the usual
+    expected input is 21 distinct strings.
+
+    Args:
+        name (str): The CamelCase string to be converted.
+
+    Returns:
+        str: The converted snake_case string.
+
+    Example:
+        >>> _camel_to_snake_case("CamelCaseString")
+        'camel_case_string'
+    """
+    # Handle the all-uppercase special case first
+    if name.isupper():
+        return name.lower()
+
+    # Convert camelCased portions to snake_case
+    name = re.sub("([a-z0-9])([A-Z])", r"\1_\2", name)
+
+    # Insert underscores between letters and digits
+    name = re.sub("([a-z])([0-9])", r"\1_\2", name)
+    name = re.sub("([0-9])([a-z])", r"\1_\2", name)
+
+    # Replace non-alphanumeric characters (excluding underscores) with underscores
+    name = re.sub(r"[^\w]", "_", name)
+
+    # Handle the remaining uppercase letters
+    name = name.lower()
+
+    return name

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from elmo.utils import _filter_data, _sanitize_session_id
+from elmo.utils import _camel_to_snake_case, _filter_data, _sanitize_session_id
 
 
 def test_filter_data_empty_data():
@@ -73,3 +73,61 @@ def test_sanitize_identifier():
     assert _sanitize_session_id("0fb182e9-474c-ca1c-f60c-ed203dbb26aa") == "0fb182e9-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
     assert _sanitize_session_id("abcdefgh-ijkl-mnop-qrst-uvwxyz012345") == "abcdefgh-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
     assert _sanitize_session_id("12345678-90ab-cdef-ghij-klmnopqrstuv") == "12345678-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+
+
+def test_camel_to_snake_case_single_word():
+    """Test conversion of a single capitalized word."""
+    assert _camel_to_snake_case("Camel") == "camel"
+
+
+def test_camel_to_snake_case_multiple_words():
+    """Test conversion of a camel-cased string with multiple words."""
+    assert _camel_to_snake_case("CamelCaseString") == "camel_case_string"
+
+
+def test_camel_to_snake_case_multiple_words_alt():
+    """Test conversion of a camel-cased string with multiple words (alternative)."""
+    assert _camel_to_snake_case("camelCaseString") == "camel_case_string"
+
+
+def test_camel_to_snake_case_single_letter():
+    """Test conversion of a single capitalized letter."""
+    assert _camel_to_snake_case("C") == "c"
+
+
+def test_camel_to_snake_case_empty_string():
+    """Test conversion of an empty string."""
+    assert _camel_to_snake_case("") == ""
+
+
+def test_camel_to_snake_case_already_snake_case():
+    """Test conversion of a string already in snake case."""
+    assert _camel_to_snake_case("already_snake_case") == "already_snake_case"
+
+
+def test_camel_to_snake_case_mixed_casing():
+    """Test conversion of a string with mixed casing."""
+    assert _camel_to_snake_case("mixedCasing_isHERE") == "mixed_casing_is_here"
+
+
+def test_camel_to_snake_case_with_numbers():
+    """Test conversion of a camel-cased string with numbers."""
+    assert _camel_to_snake_case("CamelCase1With2Numbers") == "camel_case_1_with_2_numbers"
+
+
+def test_camel_to_snake_case_with_symbols():
+    """Test conversion of a camel-cased string with numbers."""
+    assert _camel_to_snake_case("CamelCase-With-symbols") == "camel_case_with_symbols"
+
+
+def test_camel_to_snake_case_all_uppercase():
+    """Test conversion of an all-uppercase string."""
+    assert _camel_to_snake_case("UPPERCASE") == "uppercase"
+
+
+def test_camel_to_snake_case_cache(mocker):
+    """Test that cached values don't call regex twice."""
+    mocked_sub = mocker.patch("re.sub")
+    _camel_to_snake_case("camelCase")
+    _camel_to_snake_case("camelCase")
+    assert mocked_sub.call_count == 4


### PR DESCRIPTION
### Related Issues

- Closes #115 

### Proposed Changes:

`ElmoClient.get_status()` retrieves the overall main unit status. Such status includes if the alarm system has anomalies (e.g. bypassed inputs, GSM issues, etc...), if it has been tampered or if the alarm is set. External integrations may use such values to trigger automations.

This function returns a dict with the following values:
```python
result == {
        "inputs_led": 2,
        "anomalies_led": 1,
        "alarm_led": 0,
        "tamper_led": 0,
        "has_anomaly": False,
        "panel_tamper": 0,
        "panel_no_power": 0,
        "panel_low_battery": 0,
        "gsm_anomaly": 0,
        "gsm_low_balance": 0,
        "pstn_anomaly": 0,
        "system_test": 0,
        "module_registration": 0,
        "rf_interference": 0,
        "input_failure": 0,
        "input_alarm": 0,
        "input_bypass": 0,
        "input_low_battery": 0,
        "input_no_supervision": 0,
        "device_tamper": 0,
        "device_failure": 0,
        "device_no_power": 0,
        "device_low_battery": 0,
        "device_no_supervision": 0,
        "device_system_block": 0,
    }
```

### Testing:

n/a

### Extra Notes (optional):

n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
