### PR TITLE
fix(client): raise `InvalidToken` if the token expires while using `lock()`

### DIFF
--- a/src/elmo/api/client.py
+++ b/src/elmo/api/client.py
@@ -14,6 +14,7 @@ from .exceptions import (
     CredentialError,
     InvalidInput,
     InvalidSector,
+    InvalidToken,
     LockError,
     ParseError,
     QueryNotValid,
@@ -172,10 +173,12 @@ class ElmoClient:
         try:
             response.raise_for_status()
         except HTTPError as err:
-            # 403: Not possible to obtain the lock, probably because of a race condition
-            # with another application
+            # 403: Unable obtain the lock (race condition with another application)
             if err.response.status_code == 403:
                 raise LockError
+            # 401: The token has expired
+            if err.response.status_code == 401:
+                raise InvalidToken
             raise err
 
         # A wrong code returns 200 with a fail state

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -601,6 +601,19 @@ def test_client_lock_called_twice(server, mocker):
     assert len(server.calls) == 1
 
 
+def test_client_lock_invalid_token(server, mocker):
+    """Should raise a CodeError if the token is expired while calling Lock()."""
+    server.add(responses.POST, "https://example.com/api/panel/syncLogin", status=401)
+    client = ElmoClient(base_url="https://example.com", domain="domain")
+    client._session_id = "test"
+    mocker.patch.object(client, "unlock")
+    # Test
+    with pytest.raises(InvalidToken):
+        with client.lock("test"):
+            pass
+    assert len(server.calls) == 1
+
+
 def test_client_lock_unknown_error(server, mocker):
     """Should raise an Exception for unknown status code."""
     server.add(


### PR DESCRIPTION
### Related Issues

- Related to https://github.com/palazzem/ha-econnect-alarm/issues/117

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
`lock()` method uses the `@contextmanager` decorator that doesn't propagate inner exception. If a 401 response is received (the token is expired), that error is not propagated above and it causes the token to not get refreshed until the next `poll()`. In a real scenario where you have delays, it means it's very likely that you can't interact with the system unless you hit the exact window between one refresh and another.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Acquire a token, let it expire, call `lock()`

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
