### PR TITLE
fix(log)!: `Invalid*` exceptions replaced with `CommandError`; errors are logged with the API response

### DIFF
--- a/src/elmo/api/exceptions.py
+++ b/src/elmo/api/exceptions.py
@@ -70,13 +70,7 @@ class CodeError(APIException):
     default_message = "Digited panel code is not correct"
 
 
-class InvalidSector(APIException):
-    """Exception raised when armed/disarmed sector doesn't exist."""
+class CommandError(APIException):
+    """Exception raised when the API returns an error response after issuing a command."""
 
-    default_message = "Selected sector doesn't exist."
-
-
-class InvalidInput(APIException):
-    """Exception raised when included/excluded input doesn't exist."""
-
-    default_message = "Selected input doesn't exist."
+    default_message = "An error occurred while executing the command."

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,9 +8,8 @@ from elmo import query
 from elmo.api.client import ElmoClient
 from elmo.api.exceptions import (
     CodeError,
+    CommandError,
     CredentialError,
-    InvalidInput,
-    InvalidSector,
     InvalidToken,
     LockError,
     LockNotAcquired,
@@ -889,7 +888,7 @@ def test_client_arm_fails_wrong_sector(server):
     client._session_id = "test"
     client._lock.acquire()
     # Test
-    with pytest.raises(InvalidSector):
+    with pytest.raises(CommandError):
         assert client.arm([200])
 
 
@@ -1041,7 +1040,7 @@ def test_client_disarm_fails_wrong_sector(server):
     client._session_id = "test"
     client._lock.acquire()
     # Test
-    with pytest.raises(InvalidSector):
+    with pytest.raises(CommandError):
         assert client.disarm([200])
 
 
@@ -1172,7 +1171,7 @@ def test_client_include_fails_wrong_input(server):
     client._session_id = "test"
     client._lock.acquire()
     # Test
-    with pytest.raises(InvalidInput):
+    with pytest.raises(CommandError):
         assert client.include([9000])
 
 
@@ -1303,7 +1302,7 @@ def test_client_exclude_fails_wrong_input(server):
     client._session_id = "test"
     client._lock.acquire()
     # Test
-    with pytest.raises(InvalidInput):
+    with pytest.raises(CommandError):
         assert client.exclude([9000])
 
 
@@ -1414,7 +1413,7 @@ class TestTurnOn:
         client = ElmoClient(base_url="https://example.com", domain="domain")
         client._session_id = "test"
         # Test
-        with pytest.raises(InvalidInput):
+        with pytest.raises(CommandError):
             assert client.turn_on([9000])
 
     def test_client_fails_unknown_error(self, server):
@@ -1523,7 +1522,7 @@ class TestTurnOff:
         client = ElmoClient(base_url="https://example.com", domain="domain")
         client._session_id = "test"
         # Test
-        with pytest.raises(InvalidInput):
+        with pytest.raises(CommandError):
             assert client.turn_off([9000])
 
     def test_client_fails_unknown_error(self, server):


### PR DESCRIPTION
### Related Issues

- Closes [#112](https://github.com/palazzem/ha-econnect-alarm/issues/112)

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Instead of raising multiple exceptions and assuming what the error is, we raise a single `CommandError` exception when any command fails. Furthermore, we log the actual backend response, if any.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
