### PR TITLE
feat: `lock()` accepts an optional `userId`

### DIFF
--- a/src/elmo/api/client.py
+++ b/src/elmo/api/client.py
@@ -153,13 +153,15 @@ class ElmoClient:
 
     @contextmanager
     @require_session
-    def lock(self, code):
+    def lock(self, code, user_id=1):
         """Context manager to obtain a system lock. The alerting system allows
         only one user at a time and obtaining the lock is mandatory. When the
         context manager is closed, the lock is automatically released.
 
         Args:
             code: the alarm code used to obtain the lock.
+            user_id: the `userId` used by some main units. This value is optional and
+                should be used only if the main unit requires it. The default value is 1.
         Raises:
             CodeError: if used `code` is not valid.
             LockError: if the server is refusing to assign the lock. It could mean
@@ -169,7 +171,8 @@ class ElmoClient:
         Returns:
             A client instance with an acquired lock.
         """
-        payload = {"userId": 1, "password": code, "sessionId": self._session_id}
+        # Main units that do not require a userId param, expects userId to be "1"
+        payload = {"userId": user_id, "password": code, "sessionId": self._session_id}
         response = self._session.post(self._router.lock, data=payload)
 
         try:


### PR DESCRIPTION
### Related Issues

- Closes #141 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Adds `user_id` optional parameter to `lock()`. This change adds support for all main units that require the `userId` parameter during the unit authentication.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
