### PR TITLE
feat(api): handle main unit disconnections

### DIFF
--- a/src/elmo/api/exceptions.py
+++ b/src/elmo/api/exceptions.py
@@ -74,3 +74,9 @@ class CommandError(APIException):
     """Exception raised when the API returns an error response after issuing a command."""
 
     default_message = "An error occurred while executing the command."
+
+
+class DeviceDisconnectedError(APIException):
+    """Exception raised when the device is disconnected."""
+
+    default_message = "Unable to execute commands. Device is disconnected."

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,7 @@ from elmo.api.exceptions import (
     CodeError,
     CommandError,
     CredentialError,
+    DeviceDisconnectedError,
     InvalidToken,
     LockError,
     LockNotAcquired,
@@ -2411,6 +2412,22 @@ def test_client_query_invalid_response(server, mocker):
     mocker.patch.object(client, "_get_descriptions")
     # Test
     with pytest.raises(ParseError):
+        client.query(query.SECTORS)
+
+
+def test_client_query_unit_disconnected(server, mocker):
+    # Ensure that the client catches and raises an exception when the unit is disconnected
+    server.add(
+        responses.POST,
+        "https://example.com/api/areas",
+        body='"Centrale non connessa"',
+        status=403,
+    )
+    client = ElmoClient(base_url="https://example.com", domain="domain")
+    client._session_id = "test"
+    mocker.patch.object(client, "_get_descriptions")
+    # Test
+    with pytest.raises(DeviceDisconnectedError):
         client.query(query.SECTORS)
 
 


### PR DESCRIPTION
### Related Issues

- Closes #146 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
Raises a `DeviceDisconnectedError` if the main unit is disconnected.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Disconnect the unit and call the `client.query()`.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
