### PR TITLE
fix(client): determine the `last_id` by finding the maximum `Id` in the list

### DIFF
--- a/src/elmo/api/client.py
+++ b/src/elmo/api/client.py
@@ -643,8 +643,17 @@ class ElmoClient:
             entries = response.json()
             _LOGGER.debug(f"Client | Query response: {entries}")
             items = {}
+
+            try:
+                # Determine the last_id by finding the maximum Id in the list
+                last_id = max(entry["Id"] for entry in entries)
+            except (TypeError, ValueError) as err:
+                _LOGGER.error("Client | Could not determine max Id from entries, defaulting to 0.")
+                _LOGGER.debug(f"Client | Error: {err} | Entries: {entries}")
+                last_id = 0
+
             result = {
-                "last_id": entries[-1]["Id"],
+                "last_id": last_id,
                 key_group: items,
             }
             try:


### PR DESCRIPTION
### Related Issues

- Fix #154 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This change removes the assumption that items ID returned from the Cloud API, are ordered.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Home Assistant integration polling should work again.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
