### PR TITLE
fix(api): set `Referer` and `Origin` headers to make polling work

### DIFF
--- a/src/elmo/api/client.py
+++ b/src/elmo/api/client.py
@@ -9,6 +9,7 @@ from requests.exceptions import HTTPError
 
 from .. import query as q
 from ..__about__ import __version__
+from ..systems import ELMO_E_CONNECT
 from ..utils import _camel_to_snake_case, _sanitize_session_id
 from .decorators import require_lock, require_session
 from .exceptions import (
@@ -49,10 +50,21 @@ class ElmoClient:
         self._session_id = session_id
         self._panel = None
         self._lock = Lock()
+
+        # Conditionally add required headers
+        if self._router._base_url == ELMO_E_CONNECT:
+            self._session.headers.update(
+                {
+                    "Referer": "https://webservice.elmospa.com/",
+                    "Origin": "https://webservice.elmospa.com",
+                }
+            )
+
         # Debug
         _LOGGER.debug(f"Client | Library version: {__version__}")
         _LOGGER.debug(f"Client | Router: {self._router._base_url}")
         _LOGGER.debug(f"Client | Domain: {self._domain}")
+        _LOGGER.debug(f"Client | HTTP Headers: {self._session.headers}")
 
     def auth(self, username, password):
         """Authenticate the client and retrieves the access token. This method uses

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2657,3 +2657,16 @@ def test_client_query_last_id_value_error_empty(server, mocker):
     # Test
     inputs = client.query(query.INPUTS)
     assert inputs["last_id"] == 0
+
+
+def test_client_constructor_sets_required_headers():
+    """Should set required Referer and Origin headers during initialization otherwise
+    polling will fail. Metronet systems do not require these headers.
+    Regression test for: https://github.com/palazzem/econnect-python/issues/158
+    """
+    client_econnect = ElmoClient(base_url=ELMO_E_CONNECT)
+    client_metronet = ElmoClient(base_url=IESS_METRONET)
+    assert client_econnect._session.headers["Referer"] == "https://webservice.elmospa.com/"
+    assert client_econnect._session.headers["Origin"] == "https://webservice.elmospa.com"
+    assert "Referer" not in client_metronet._session.headers
+    assert "Origin" not in client_metronet._session.headers


### PR DESCRIPTION
### Related Issues

- Fixes #158 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This change sets `Origin` and `Referer` headers during client initialization. The change is required otherwise polling will not work.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
