### PR TITLE
fix(api): use web login for e-Connect to register the client for long-polling

### DIFF
--- a/src/elmo/api/client.py
+++ b/src/elmo/api/client.py
@@ -9,7 +9,12 @@ from requests.exceptions import HTTPError
 
 from .. import query as q
 from ..__about__ import __version__
-from ..utils import _camel_to_snake_case, _sanitize_session_id
+from ..systems import ELMO_E_CONNECT
+from ..utils import (
+    _camel_to_snake_case,
+    _sanitize_session_id,
+    extract_session_id_from_html,
+)
 from .decorators import require_lock, require_session
 from .exceptions import (
     CodeError,
@@ -49,6 +54,7 @@ class ElmoClient:
         self._session_id = session_id
         self._panel = None
         self._lock = Lock()
+
         # Debug
         _LOGGER.debug(f"Client | Library version: {__version__}")
         _LOGGER.debug(f"Client | Router: {self._router._base_url}")
@@ -56,7 +62,7 @@ class ElmoClient:
 
     def auth(self, username, password):
         """Authenticate the client and retrieves the access token. This method uses
-        the Authentication API.
+        the Authentication API, or the web login form if the base_url is Elmo E-Connect.
 
         Args:
             username: the Username used for the authentication.
@@ -69,11 +75,28 @@ class ElmoClient:
             the `ElmoClient` instance.
         """
         try:
+            if self._router._base_url == ELMO_E_CONNECT:
+                # Web login is required for Elmo E-Connect because, at the moment, the
+                # e-Connect Cloud API login does not register the client session in the backend.
+                # This prevents the client from attaching to server events (e.g. long polling updates).
+                web_login_url = f"https://webservice.elmospa.com/{self._domain}"
+                payload = {
+                    "IsDisableAccountCreation": "True",
+                    "IsAllowThemeChange": "True",
+                    "UserName": username,
+                    "Password": password,
+                    "RememberMe": "false",
+                }
+                _LOGGER.debug("Client | e-Connect Web Login detected")
+                web_response = self._session.post(web_login_url, data=payload)
+                web_response.raise_for_status()
+
+            # API login
             payload = {"username": username, "password": password}
             if self._domain is not None:
                 payload["domain"] = self._domain
 
-            _LOGGER.debug("Client | Client Authentication")
+            _LOGGER.debug("Client | API Authentication")
             response = self._session.get(self._router.auth, params=payload)
             response.raise_for_status()
         except HTTPError as err:
@@ -84,8 +107,11 @@ class ElmoClient:
 
         # Store the session_id and the panel details (if available)
         data = response.json()
-        self._session_id = data["SessionId"]
         self._panel = {_camel_to_snake_case(k): v for k, v in data.get("Panel", {}).items()}
+        if self._router._base_url == ELMO_E_CONNECT:
+            self._session_id = extract_session_id_from_html(web_response.text)
+        else:
+            self._session_id = data["SessionId"]
 
         # Register the redirect URL and try the authentication again
         if data["Redirect"]:

--- a/src/elmo/utils.py
+++ b/src/elmo/utils.py
@@ -2,6 +2,8 @@ import logging
 import re
 from functools import lru_cache
 
+from .api.exceptions import ParseError
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -58,3 +60,29 @@ def _camel_to_snake_case(name):
     name = name.lower()
 
     return name
+
+
+def extract_session_id_from_html(html_content: str) -> str:
+    """Extract the session ID from the HTML source containing the specific JavaScript block.
+
+    This function uses a raw string (r"") for the regex pattern to avoid escaping issues.
+    The regex pattern is designed to find "var sessionId = '...'" and capture the ID within the quotes.
+    It captures any character except the closing single quote.
+
+    Args:
+        html_content (str): The HTML source code as a string.
+
+    Returns:
+        str: The extracted session ID string.
+
+    Raises:
+        ParseError: If the session ID is not found in the HTML content.
+    """
+    pattern = r"var\s+sessionId\s*=\s*'([^']+)'"
+    match = re.search(pattern, html_content)
+    if match:
+        return match.group(1)
+    else:
+        _LOGGER.error("Client | Session ID not found in e-Connect status page.")
+        _LOGGER.debug("Client | HTML content: %s", html_content)
+        raise ParseError("Session ID not found in e-Connect status page.")

--- a/tests/fixtures/responses.py
+++ b/tests/fixtures/responses.py
@@ -96,6 +96,7 @@ LOGIN = """
         "PrivacyLink": "/PrivacyAndTerms/v1/Informativa_privacy_econnect_2020_09.pdf",
         "TermsLink": "/PrivacyAndTerms/v1/CONTRATTO_UTILIZZATORE_FINALE_2020_02_07.pdf"
     }"""
+
 UPDATES = """
     {
         "ConnectionStatus": false,
@@ -118,6 +119,7 @@ UPDATES = """
         "HasChanges": true
     }
 """
+
 SYNC_LOGIN = """[
     {
         "Poller": {"Poller": 1, "Panel": 1},
@@ -125,6 +127,7 @@ SYNC_LOGIN = """[
         "Successful": true
     }
 ]"""
+
 SYNC_LOGOUT = """[
     {
         "Poller": {"Poller": 1, "Panel": 1},
@@ -132,6 +135,7 @@ SYNC_LOGOUT = """[
         "Successful": true
     }
 ]"""
+
 SYNC_SEND_COMMAND = """[
     {
         "Poller": {"Poller": 1, "Panel": 1},
@@ -139,6 +143,7 @@ SYNC_SEND_COMMAND = """[
         "Successful": true
     }
 ]"""
+
 STRINGS = """[
     {
         "AccountId": 1,
@@ -229,6 +234,7 @@ STRINGS = """[
         "Version": "AAAAAAAAgRw="
     }
 ]"""
+
 AREAS = """[
    {
        "Active": true,
@@ -283,6 +289,7 @@ AREAS = """[
        "InProgress": false
    }
 ]"""
+
 INPUTS = """[
    {
        "Alarm": true,
@@ -333,6 +340,7 @@ INPUTS = """[
        "InProgress": false
    }
 ]"""
+
 OUTPUTS = """[
    {
        "Active": true,
@@ -379,3 +387,341 @@ OUTPUTS = """[
        "InProgress": false
    }
 ]"""
+
+STATUS_PAGE = """
+<script type="text/javascript">
+    var sessionTimeout = 1200000;
+    var apiURL = 'https://connect.elmospa.com/api/';
+    var sessionId = 'f8h23b4e-7a9f-4d3f-9b08-2769263ee33c';
+
+    var canElevate = '1';
+    var connectionStatus = '1';
+    var loggedIn = '0';
+    var loggedInProgress = '0';
+    var isUserIdRequired = 'False' == "True";
+    var isFirePanel = 'False' == "True";
+    var lastStatusAdvId = '0';
+
+    var readStringsInProgress = 0;
+    var strings = 1;
+    var sendCommandCntrl = null;
+    var managedAccountIds = [];
+    var wantToChangeNameOrCode = 0;
+    var wantToActivateSysBlock = false;
+
+            var loginUrl = '/nwd_si?webview=1';
+
+
+    var successHeader = 'Successo';
+    var errorHeader = 'Errore';
+    var connectLabelString = 'Connessa';
+    var disconnectLabelString = 'Non connessa';
+    var readStringMsg = 'Lettura dati centrale completata con successo.';
+    var panelLoginButtonString = 'Accedi';
+    var panelExitButtonString = 'Esci';
+    var panelLoadingButtonString = 'In corso';
+    var panelBusyButtonString = 'In Uso';
+    var capsLockMsg = 'Caps lock abilitato.';
+    var okButtonText = 'Ok';
+    var cancelButtonText = 'Annulla';
+
+    var offset = 200;
+    var duration = 500;
+    var isSaveThermostatSettings = false;
+    var tAll = 0;
+    var tProgram = false;
+
+    var logoInterval = "";
+    var i = 0;
+
+    var panelStatus;
+
+    var isQhuboUser = 'False' == "True";
+
+    //Tables common responsive breakpoints
+    var breakpoints = [
+        { name: 'brkXXL', width: 1800 },
+        { name: 'brkXL', width: 1700 },
+        { name: 'brkLG', width: 1400 },
+        { name: 'brkMD', width: 1100 },
+        { name: 'brkSM', width: 992 },
+        { name: 'brkXS', width: 550 },
+        { name: 'brkXXS', width: 480 }
+    ]
+
+    $(document).ready(function () {
+        window.addEventListener("beforeunload", () => {
+
+        });
+
+        $('input[type=checkbox], input[type=radio]').customRadioCheck();
+        initializeControls();
+        $('.scroll-to-top').hide();
+
+        $(window).scroll(function () {
+            if ($(this).scrollTop() > offset)
+                $('.scroll-to-top').fadeIn(duration);
+            else
+                $('.scroll-to-top').fadeOut(duration);
+        });
+
+        $('.scroll-to-top').click(function (event) {
+            event.preventDefault();
+            $('html, body').animate({ scrollTop: 0 }, duration);
+            return false;
+        });
+
+        $('.paneldetailarrow').click(function () {
+            if (!$('.paneldetailarrow i').hasClass('down')) {
+                $('.paneldetailarrow i').addClass('down');
+                $('#mainPanelDetail').slideDown(500);
+            } else {
+                $('.paneldetailarrow i').removeClass('down');
+                $('#mainPanelDetail').slideUp(500);
+            }
+        });
+
+        if (isQhuboUser) {
+            $('.qhubo-area.area-disarmed, a.status-idle[data-elementclass=9]').hover(
+                function () {
+                    $(this).children('i').removeClass('icoN-login-unlock').addClass('icoN-login-lock');
+                }, function () {
+                    $(this).children('i').removeClass('icoN-login-lock').addClass('icoN-login-unlock');
+                }
+            );
+
+            $('.qhubo-area.area-armed, a.status-armed[data-elementclass=9]').hover(
+                function () {
+                    $(this).children('i').removeClass('icoN-login-lock').addClass('icoN-login-unlock');
+                }, function () {
+                    $(this).children('i').removeClass('icoN-login-unlock').addClass('icoN-login-lock');
+                }
+            );
+        }
+
+        var backURL = $(this).attr("href");
+        if (backURL != undefined) {
+            backURL = backURL.replace('/undefined', '');
+            history.pushState({}, $(this).attr("title"), backURL);
+
+            $("a").each(function () {
+                $(this).attr('href', backURL);
+            });
+        }
+
+        setTimeout(function () {
+            $("#ErrorMsgBox input, #ErrorMsgBox .close").hide();
+            showErrorMsg("", "Errore", "Sessione scaduta. Verrai reindirizzato alla pagina di accesso a breve.");
+
+            setTimeout(function () {
+                window.location.href = loginUrl;
+            }, 3000);
+        }, sessionTimeout);
+    });
+
+    $('.paneldetailarrow').click(function () {
+        var isOpen = getCookie("pnlClosed");
+        if (isOpen == "1")
+            setCookie("pnlClosed", "0");
+        else if (isOpen == "0")
+            setCookie("pnlClosed", "1");
+        else {
+            if ($("#mainPanelDetail").is(":visible"))
+                setCookie("pnlClosed", "1");
+            else
+                setCookie("pnlClosed", "0");
+        }
+    });
+
+    $(window).resize(function () {
+        initializeControls();
+        roundTables();
+    });
+
+    function showLoading() {
+        $('.loader').show();
+    }
+
+    function hideLoading() {
+        $('.loader').hide();
+    }
+
+    function initializeControls() {
+        if ($(window).width() < 979) {
+            $('#infobox').insertAfter('#main_content #divDashArea');
+
+            $('#infobox .col-4').unbind('click').click(function (e) {
+                if ($(e.target).hasClass('h2infobox')) {
+                    if (!$(this).children('.content').hasClass('opened'))
+                        $(this).children('.content').addClass('opened').slideDown();
+                    else
+                        $(this).children('.content').removeClass('opened').slideUp();
+                }
+            });
+
+            $('.infobox .col-4 .divInfobox').eq(0).next('.content').addClass('opened').show();
+            $('.infobox .col-4 .divInfobox').unbind('click').click(function (e) {
+                if ($(e.target).attr('id') != 'configureBtn') {
+                    if ($('#configureBtn').hasClass('close'))
+                        $('#configureBtn').trigger('click');
+
+                    if (!$(this).next('.content').hasClass('opened')) {
+                        $('.graph-container').css('min-height', 'auto')
+
+                        $(this).next('.content').addClass('opened').slideDown(function () {
+                            $('.graph-container').css('min-height', '400px');
+                        });
+                    } else {
+                        $('.graph-container').css('min-height', 'auto');
+                        $(this).next('.content').removeClass('opened').slideUp();
+                    }
+
+                    if ($('.infobox .col-4 .divInfobox').index(this) == 3)
+                        $(window).resize();
+                }
+            });
+        } else {
+            $('#infobox .col-4 .content').removeAttr('style');
+            $('.infobox .col-4 .divInfobox').removeAttr('style');
+            $('#infobox').insertAfter('#main_content .dashboard-body');
+            $('#infobox .col-4').unbind('click');
+            $('.infobox .col-4 .divInfobox').next('.content').removeAttr('style')
+        }
+
+        if ($(window).width() < 768) {
+            if (isQhuboUser) {
+                $(".main-logo").attr('src', "Content/themes/theme-22/Images/footer-logo.png");
+                $('.logged-panel').show();
+            }
+
+            if (!$('#main_content #divPanelDetail').length) {
+                $('#divPanelDetail').appendTo('#main_content');
+                $('.paneldetailarrow i').addClass('down');
+            }
+
+            if (!$('#sidebar #divLanguageOptions').length) {
+                $('#divLanguageOptions').insertBefore($('#sidebar #divPanelSiteInfo').parent());
+                $('#divLanguageAlign').removeClass('align-right');
+            }
+
+            $('h6').hide();
+            $('#user_menu').show();
+            $('#lnkLogo').prependTo('#divLogoMobile');
+
+            setTimeout(function () {
+                $('#divLanguageOptions').removeClass('visible-desktop');
+            }, 300);
+
+            if (getCookie("pnlClosed") == "1") {
+                $("#mainPanelDetail").hide();
+                $('.paneldetailarrow i').removeClass('down');
+            } else if (getCookie("pnlClosed") == "0") {
+                $("#mainPanelDetail").show();
+                $('.paneldetailarrow i').addClass('down');
+            } else {
+                setTimeout(function () {
+                    if ($('.paneldetailarrow i').hasClass('down')) {
+                        $('.paneldetailarrow').click();
+                        setCookie("pnlClosed", "1");
+                    }
+                }, 2000);
+            }
+
+            clearInterval(logoInterval);
+            logoInterval = 0;
+
+            if (!isQhuboUser)
+                logoInterval = setInterval(changeHeader, 5000);
+        } else if ((mobileDevices.test(navigator.userAgent) || isIOS13Devices) &&
+            $(window).width() > 768 && $(window).height() < 420) {
+            if (!$('.paneldetailarrow i').hasClass('down')) {
+                $('.paneldetailarrow').click();
+            }
+
+            clearInterval(logoInterval);
+            logoInterval = 0;
+            $(".main-logo").show();
+            $(".main-logo").removeClass("animate__fadeInDown");
+            $(".main-logo").removeClass("animate__fadeOut");
+            $(".logged-panel").hide();
+            $('h6').show();
+            $('#user_menu').hide();
+            $('#lnkLogo').appendTo('#divLogo');
+
+            if (isQhuboUser)
+                $(".main-logo").attr('src', "Images/dashboard-logo.png");
+
+            if (!$('.sidebar--scroll #divPanelDetail').length)
+                $('#divPanelDetail').appendTo('.sidebar--scroll');
+
+            if (!$('#main_content #divLanguageOptions').length) {
+                $('#divLanguageOptions').prependTo('#main_content');
+                $('#divLanguageAlign').addClass('align-right');
+            }
+        } else {
+            clearInterval(logoInterval);
+            logoInterval = 0;
+            $(".main-logo").show();
+            $(".main-logo").removeClass("animate__fadeInDown");
+            $(".main-logo").removeClass("animate__fadeOut");
+            $(".logged-panel").hide();
+            $('h6').show();
+            $('#user_menu').hide();
+            $('#lnkLogo').appendTo('#divLogo');
+
+            if (isQhuboUser)
+                $(".main-logo").attr('src', "Images/dashboard-logo.png");
+
+            if (!$('#sidebar #divPanelDetail').length) {
+                $('#divPanelDetail').appendTo('.sidebar--scroll');
+                $('#mainPanelDetail').show();
+            }
+
+            if (!$('#main_content #divLanguageOptions').length) {
+                $('#divLanguageOptions').prependTo('#main_content');
+                $('#divLanguageAlign').addClass('align-right');
+            }
+        }
+    }
+
+    function roundTables() {
+        $('table.dataTable thead tr th, table.dataTable tbody tr td').css('border-radius', '');
+        $('table.dataTable thead tr th, table.dataTable tbody tr td').css('border', '0');
+
+        $('table.dataTable').each(function () {
+            $(this).find('tr').each(function () {
+                $(this).css('border-bottom', '1px solid');
+
+                $(this).find('th:visible:first').css('border-top-left-radius', '10px');
+                $(this).find('th:visible:last').css('border-top-right-radius', '10px');
+
+                $(this).find('th:visible:not(:last)').css('border-right', '1px solid');
+                $(this).find('td:visible:not(:last)').css('border-right', '1px solid');
+            });
+
+            $(this).find('tr:last').css('border-bottom', '0');
+            $(this).find('tr:last td:visible:first').css('border-bottom-left-radius', '10px');
+            $(this).find('tr:last td:visible:last').css('border-bottom-right-radius', '10px');
+        });
+    }
+
+    function changeHeader() {
+        if (i == 0) {
+            $(".main-logo").removeClass("animate__fadeInDown");
+            $(".main-logo").addClass("animate__fadeOut");
+
+            $(".logged-panel").show();
+            $(".logged-panel").removeClass("animate__fadeOut");
+            $(".logged-panel").addClass("animate__fadeInDown");
+            i = 1;
+        } else {
+            $(".main-logo").removeClass("animate__fadeOut");
+            $(".main-logo").addClass("animate__fadeInDown");
+
+            $(".logged-panel").removeClass("animate__fadeInDown");
+            $(".logged-panel").addClass("animate__fadeOut");
+            i = 0;
+        }
+    }
+</script>
+"""

--- a/tests/scripts/debug_polling.py
+++ b/tests/scripts/debug_polling.py
@@ -1,0 +1,65 @@
+"""
+Debug script for polling e-Connect/IESS alarm systems.
+
+This script connects to an e-Connect/IESS alarm system via the E-Connect or Metronet
+cloud platform, authenticates using provided credentials, and continuously polls
+for updates on sectors, inputs, outputs, alerts, and panel status.
+
+It prints the 'last_id' received for each category in every poll cycle.
+
+Usage:
+    python tests/scripts/debug_polling.py <system> <domain> <username> <password>
+
+Arguments:
+    domain: The domain identifier for the alarm system (e.g., vendor).
+    system: The cloud platform to connect to ('econnect' or 'iess').
+    username: The username for authentication.
+    password: The password for authentication.
+"""
+
+import argparse
+
+from elmo import query as q
+from elmo import systems
+from elmo.api.client import ElmoClient
+
+if __name__ == "__main__":
+    # Argument Parsing
+    parser = argparse.ArgumentParser(description="Poll e-Connect/IESS alarm systems.")
+    parser.add_argument("system", choices=["econnect", "iess"], help="Cloud platform ('econnect' or 'iess').")
+    parser.add_argument("domain", help="Domain identifier for the alarm system.")
+    parser.add_argument("username", help="Username for authentication.")
+    parser.add_argument("password", help="Password for authentication.")
+    args = parser.parse_args()
+
+    # Determine system URL
+    system_url = systems.ELMO_E_CONNECT if args.system == "econnect" else systems.IESS_METRONET
+
+    # Initialize Client
+    client = ElmoClient(base_url=system_url, domain=args.domain)
+    client.auth(args.username, args.password)
+    print("Authenticated")
+    last_ids = {}
+
+    # Poll the system
+    while True:
+        sectors = client.query(q.SECTORS)
+        inputs = client.query(q.INPUTS)
+        outputs = client.query(q.OUTPUTS)
+        alerts = client.query(q.ALERTS)
+        panel = client.query(q.PANEL)
+
+        last_ids[q.SECTORS] = sectors.get("last_id", 0)
+        last_ids[q.INPUTS] = inputs.get("last_id", 0)
+        last_ids[q.OUTPUTS] = outputs.get("last_id", 0)
+        last_ids[q.ALERTS] = alerts.get("last_id", 0)
+        last_ids[q.PANEL] = panel.get("last_id", 0)
+
+        print("-" * 100)
+        print(f"Sectors: {sectors['last_id']}")
+        print(f"Inputs: {inputs['last_id']}")
+        print(f"Outputs: {outputs['last_id']}")
+        print(f"Alerts: {alerts['last_id']}")
+        print(f"Panel: {panel['last_id']}")
+        print("-" * 100)
+        client.poll(last_ids)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,13 @@
-from elmo.utils import _camel_to_snake_case, _sanitize_session_id
+import pytest
+
+from elmo.api.exceptions import ParseError
+from elmo.utils import (
+    _camel_to_snake_case,
+    _sanitize_session_id,
+    extract_session_id_from_html,
+)
+
+from .fixtures.responses import STATUS_PAGE
 
 
 def test_sanitize_identifier():
@@ -64,3 +73,16 @@ def test_camel_to_snake_case_cache(mocker):
     _camel_to_snake_case("camelCase")
     _camel_to_snake_case("camelCase")
     assert mocked_sub.call_count == 4
+
+
+def test_extract_session_id_from_html():
+    """Ensure the session ID is extracted from e-Connect status page."""
+    html_content = STATUS_PAGE
+    assert extract_session_id_from_html(html_content) == "f8h23b4e-7a9f-4d3f-9b08-2769263ee33c"
+
+
+def test_extract_session_id_from_html_no_session_id():
+    """Ensure an error is raised when the session ID is not found in the HTML content."""
+    html_content = STATUS_PAGE.replace("var sessionId = 'f8h23b4e-7a9f-4d3f-9b08-2769263ee33c';", "")
+    with pytest.raises(ParseError):
+        extract_session_id_from_html(html_content)


### PR DESCRIPTION
### Related Issues

- Fixes #158 

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This change (re)introduces the web page login when e-Connect alarm system is used. This is required as it seems the public API doesn't register the client to get updates from the long-polling API.

We introduce also `tests/scripts/debug_polling.py` debug script to verify if long-polling is working or not in a real world scenario.

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
Use `tests/scripts/debug_polling.py` to see if long polling works in your scenario.

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
This is a temporary change as it looks like Elmo is making updates to the Cloud API. As soon as a new public and documented API is out, we'll probably drop this approach in favor of something more reliable.

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
