### PR TITLE
feat(python)!: support Python 3.9 -> 3.13

### DIFF
--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   econnect:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/building.yaml
+++ b/.github/workflows/building.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: |
-            3.11
+            3.13
 
       - name: Upgrade pip and install required tools
         run: |

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   econnect:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Upgrade pip and install required tools
         run: |

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   econnect:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       TOX_SKIP_ENV: lint
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -28,11 +28,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: |
-            3.8
             3.9
             3.10
             3.11
             3.12
+            3.13
 
       - name: Upgrade pip and install required tools
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "econnect-python"
 dynamic = ["version"]
 description = 'API adapter used to control programmatically an Elmo alarm system'
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "Apache-2.0"
 keywords = []
 authors = [
@@ -16,10 +16,11 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
     lint
-    py3.8
     py3.9
     py3.10
     py3.11
     py3.12
+    py3.13
 
 [testenv]
 allowlist_externals = pytest


### PR DESCRIPTION
### Related Issues

n/a

### Proposed Changes:
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
 <!--- In case of a feature: Describe what did you add and how it works -->
This change drops support for Python 3.8 and extends support for Python 3.9 -> 3.13. In this PR we also update GitHub runner OS versions to `ubuntu-24.04` as the previous one is now unsupported (see: https://github.com/palazzem/econnect-python/actions/runs/14539342374)

### Testing:
<!-- unit tests, integration tests, manual verification, instructions for manual tests -->
n/a

### Extra Notes (optional):
<!-- E.g. point out sections where the reviewer should validate your reasoning -->
<!-- E.g. point out questions that are still opened -->
n/a

### Checklist

- [x] Related issues and proposed changes are filled
- [x] Tests are defining the correct and expected behavior
- [x] Code is well-documented via docstrings
